### PR TITLE
Remove project_id

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,6 @@ jobs:
         name: Deploy to App Engine
         uses: google-github-actions/deploy-appengine@v1
         with:
-          project_id: spmbc
           env_vars: |-
             AUTH0_ISSUER=${{ secrets.AUTH0_ISSUER }}
             CLOUDINARY_URL=${{ secrets.CLOUDINARY_URL }}


### PR DESCRIPTION
Hopefully this fixes the deploys, but removing the `project_id` since it's already (presumably) in the service account. I might add it back in later though, just in case I change the value of the service account.