### PR TITLE
Start Command

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -18,7 +18,7 @@ node_modules/
 
 src/
 tsconfig.json
-package*.json
+package-lock.json
 README.md
 
 .env*

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "The webservice that will retrieve data requests for the St. Phillips Missionary Baptist Church.",
   "main": "src/app.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node dist/app.js",
     "build": "tsc -p tsconfig.json",
     "dev": "ts-node-dev src/app.ts",


### PR DESCRIPTION
`npm start` is obviously in package.json, which I was ignoring for some reason in .gcloudignore. Hopefully this gets the build working as intended.