### PR TITLE
Node 18

### DIFF
--- a/src/config/db.ts
+++ b/src/config/db.ts
@@ -5,7 +5,7 @@ dotenv.config()
 
 const url = process.env.NODE_ENV === 'production'
   ? `mongodb+srv://${process.env.MONGO_USER}:${process.env.MONGO_PASSWORD}@spmbc.juctnny.mongodb.net/?retryWrites=true&w=majority`
-  : 'mongodb://localhost:27017';
+  : 'mongodb://127.0.0.1:27017';
 
 const client = new MongoClient(url);
 


### PR DESCRIPTION
Upon upgrading to node 18, the DB connection times out on a local connection, and changing `localhost` to `127.0.0.1` (the localhost IP), allows the connection to succeed.